### PR TITLE
Support .NET 9

### DIFF
--- a/MrAdvice.Weaver/MrAdvice.Weaver.csproj
+++ b/MrAdvice.Weaver/MrAdvice.Weaver.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras/3.0.22">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netstandard2.0;net461;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461;net6.0;net8.0;net9.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>

--- a/MrAdvice.Weaver/MrAdvice.targets
+++ b/MrAdvice.Weaver/MrAdvice.targets
@@ -7,7 +7,8 @@
 			<TargetFrameworkVersionNumber>$([System.Text.RegularExpressions.Regex]::Replace($(TargetFrameworkVersion), '[^\d\.]+', '', System.Text.RegularExpressions.RegexOptions.IgnoreCase))</TargetFrameworkVersionNumber>
 			<MrAdviceWeaverPath Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">"$(MSBuildThisFileDirectory)..\tools\net461\MrAdvice.Weaver.exe"</MrAdviceWeaverPath>
 			<MrAdviceWeaverPath Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'">"$(MSBuildThisFileDirectory)..\tools\net6.0\MrAdvice.Weaver.exe"</MrAdviceWeaverPath>
-			<MrAdviceWeaverPath Condition="'$(TargetFrameworkVersionNumber)' &gt;= '5.0'">dotnet "$(MSBuildThisFileDirectory)..\tools\net$(TargetFrameworkVersionNumber)/MrAdvice.Weaver.dll"</MrAdviceWeaverPath>
+			<MrAdviceWeaverPath Condition="'$(TargetFrameworkVersionNumber)' &gt;= '8.0'">dotnet "$(MSBuildThisFileDirectory)..\tools\net8.0\MrAdvice.Weaver.dll"</MrAdviceWeaverPath>
+			<MrAdviceWeaverPath Condition="'$(TargetFrameworkVersionNumber)' &gt;= '9.0'">dotnet "$(MSBuildThisFileDirectory)..\tools\net9.0\MrAdvice.Weaver.dll"</MrAdviceWeaverPath>
 			<MrAdviceWeaverReferencePathFile>@(IntermediateAssembly).MrAdvice.ReferencePath.txt</MrAdviceWeaverReferencePathFile>
 			<MrAdviceWeaverLocalReferencePathFile>@(IntermediateAssembly).MrAdvice.LocalReferencePath.txt</MrAdviceWeaverLocalReferencePathFile>
 		</PropertyGroup>

--- a/MrAdvice/MrAdvice.csproj
+++ b/MrAdvice/MrAdvice.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras/3.0.22">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0;net9.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>

--- a/Test/AssemblyLevelTest/AssemblyLevelTest.csproj
+++ b/Test/AssemblyLevelTest/AssemblyLevelTest.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <ProductVersion />
     <ProjectGuid>{8B8EB6C4-78BC-442D-86B1-3E8E09DCF21F}</ProjectGuid>
-    <TargetFrameworks>net461;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net461;net6.0;net8.0;net9.0</TargetFrameworks>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <AssemblyTitle>AssemblyLevelTest</AssemblyTitle>
     <Company>Microsoft</Company>

--- a/Test/DotNetCoreTest/DotNetCoreTest.csproj
+++ b/Test/DotNetCoreTest/DotNetCoreTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0;net9.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/Test/ExternalAdviceTest/ExternalAdviceTest.csproj
+++ b/Test/ExternalAdviceTest/ExternalAdviceTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras/3.0.22">
   <PropertyGroup>
     <ProjectGuid>{B9F3D5B6-8FF9-491B-8CE3-BD014885BBA9}</ProjectGuid>
-    <TargetFrameworks>net461;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net461;net6.0;net8.0;net9.0</TargetFrameworks>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <TestProjectType>UnitTest</TestProjectType>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>

--- a/Test/IntegrityTest/IntegrityTest.csproj
+++ b/Test/IntegrityTest/IntegrityTest.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <ProductVersion />
     <ProjectGuid>{492263E1-7372-47C4-BD57-14A70BB028F0}</ProjectGuid>
-    <TargetFrameworks>net461;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net461;net6.0;net8.0;net9.0</TargetFrameworks>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <AssemblyTitle>IntegrityTest</AssemblyTitle>
     <Company>Microsoft</Company>

--- a/Test/MethodLevelTest/MethodLevelTest.csproj
+++ b/Test/MethodLevelTest/MethodLevelTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras/3.0.22">
   <PropertyGroup>
     <ProjectGuid>{77928F8C-A708-4C49-B6E2-772256E75E4D}</ProjectGuid>
-    <TargetFrameworks>net461;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net461;net6.0;net8.0;net9.0</TargetFrameworks>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>

--- a/Test/TestApplication/TestApplication.csproj
+++ b/Test/TestApplication/TestApplication.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <ProjectGuid>{491EF845-625A-4535-932C-BC2B8B15FC94}</ProjectGuid>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0;net9.0</TargetFrameworks>
     <AssemblyTitle>TestApplication</AssemblyTitle>
     <Product>TestApplication</Product>
     <Copyright>Copyright ©  2016</Copyright>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ init:
 - ps: |
     $VerbosePreference = "continue"
     Invoke-WebRequest -Uri 'https://dot.net/v1/dotnet-install.ps1' -UseBasicParsing -OutFile "$env:temp\dotnet-install.ps1"
-    & $env:temp\dotnet-install.ps1 -Architecture x64 -Version '8.0.100' -InstallDir "$env:ProgramFiles\dotnet"
+    & $env:temp\dotnet-install.ps1 -Architecture x64 -Version '9.0.100' -InstallDir "$env:ProgramFiles\dotnet"
 
 branches:
   only:


### PR DESCRIPTION
Add target .NET 9.
I also modified `MrAdvice.targets` to fallback to the latest supported .NET so it will keep working when .NET 10 is released.